### PR TITLE
Separate definition of padding length

### DIFF
--- a/params.c
+++ b/params.c
@@ -185,6 +185,7 @@ int xmss_parse_oid(xmss_params *params, const uint32_t oid)
         case 0x00000008:
         case 0x00000009:
             params->n = 32;
+            params->padding_len = 32;
             break;
 
         case 0x00000004:
@@ -195,6 +196,7 @@ int xmss_parse_oid(xmss_params *params, const uint32_t oid)
         case 0x0000000b:
         case 0x0000000c:
             params->n = 64;
+            params->padding_len = 64;
             break;
 
         default:
@@ -298,6 +300,7 @@ int xmssmt_parse_oid(xmss_params *params, const uint32_t oid)
         case 0x00000017:
         case 0x00000018:
             params->n = 32;
+            params->padding_len = 32;
             break;
 
         case 0x00000009:
@@ -318,6 +321,7 @@ int xmssmt_parse_oid(xmss_params *params, const uint32_t oid)
         case 0x0000001f:
         case 0x00000020:
             params->n = 64;
+            params->padding_len = 64;
             break;
 
         default:

--- a/params.h
+++ b/params.h
@@ -14,6 +14,7 @@
 typedef struct {
     unsigned int func;
     unsigned int n;
+    unsigned int padding_len;
     unsigned int wots_w;
     unsigned int wots_log_w;
     unsigned int wots_len1;


### PR DESCRIPTION
I'm working to implement the parameter sets specified in the draft version of [NIST Special Publication 800-208](https://csrc.nist.gov/publications/detail/sp/800-208/draft).

The reference implementation of XMSS currently assumes that _n_ bytes of padding is used for the prefix in the functions prf, hash_message, thash_h, and thash_f. While this is the case for all of the parameter sets in [RFC 8391](https://www.rfc-editor.org/rfc/rfc8391.html), the draft version of [NIST Special Publication 800-208](https://csrc.nist.gov/publications/detail/sp/800-208/draft) specifies parameter sets in which the amount of padding is different than _n_.

This PR allows for the padding length for a parameter set to be specified separately from _n_.