### PR TITLE
Improved key generation

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -12,6 +12,7 @@
 #define XMSS_HASH_PADDING_H 1
 #define XMSS_HASH_PADDING_HASH 2
 #define XMSS_HASH_PADDING_PRF 3
+#define XMSS_HASH_PADDING_PRF_KEYGEN 4
 
 void addr_to_bytes(unsigned char *bytes, const uint32_t addr[8])
 {
@@ -57,6 +58,23 @@ int prf(const xmss_params *params,
     memcpy(buf + params->padding_len + params->n, in, 32);
 
     return core_hash(params, out, buf, params->padding_len + params->n + 32);
+}
+
+/*
+ * Computes PRF_keygen(key, in), for a key of params->n bytes, and an input
+ * of 32 + params->n bytes
+ */
+int prf_keygen(const xmss_params *params,
+        unsigned char *out, const unsigned char *in,
+        const unsigned char *key)
+{
+    unsigned char buf[params->padding_len + 2*params->n + 32];
+
+    ull_to_bytes(buf, params->padding_len, XMSS_HASH_PADDING_PRF_KEYGEN);
+    memcpy(buf + params->padding_len, key, params->n);
+    memcpy(buf + params->padding_len + params->n, in, params->n + 32);
+
+    return core_hash(params, out, buf, params->padding_len + 2*params->n + 32);
 }
 
 /*

--- a/hash.h
+++ b/hash.h
@@ -10,6 +10,10 @@ int prf(const xmss_params *params,
         unsigned char *out, const unsigned char in[32],
         const unsigned char *key);
 
+int prf_keygen(const xmss_params *params,
+        unsigned char *out, const unsigned char *in,
+        const unsigned char *key);
+
 int h_msg(const xmss_params *params,
           unsigned char *out,
           const unsigned char *in, unsigned long long inlen,

--- a/xmss_commons.c
+++ b/xmss_commons.c
@@ -105,35 +105,13 @@ void gen_leaf_wots(const xmss_params *params, unsigned char *leaf,
                    const unsigned char *sk_seed, const unsigned char *pub_seed,
                    uint32_t ltree_addr[8], uint32_t ots_addr[8])
 {
-    unsigned char seed[params->n];
     unsigned char pk[params->wots_sig_bytes];
 
-    get_seed(params, seed, sk_seed, ots_addr);
-    wots_pkgen(params, pk, seed, pub_seed, ots_addr);
+    wots_pkgen(params, pk, sk_seed, pub_seed, ots_addr);
 
     l_tree(params, leaf, pk, pub_seed, ltree_addr);
 }
 
-/**
- * Used for pseudo-random key generation.
- * Generates the seed for the WOTS key pair at address 'addr'.
- *
- * Takes n-byte sk_seed and returns n-byte seed using 32 byte address 'addr'.
- */
-void get_seed(const xmss_params *params, unsigned char *seed,
-              const unsigned char *sk_seed, uint32_t addr[8])
-{
-    unsigned char bytes[32];
-
-    /* Make sure that chain addr, hash addr, and key bit are zeroed. */
-    set_chain_addr(addr, 0);
-    set_hash_addr(addr, 0);
-    set_key_and_mask(addr, 0);
-
-    /* Generate seed. */
-    addr_to_bytes(bytes, addr);
-    prf(params, seed, bytes, sk_seed);
-}
 
 /**
  * Verifies a given message signature pair under a given public key.

--- a/xmss_commons.h
+++ b/xmss_commons.h
@@ -14,15 +14,6 @@ void gen_leaf_wots(const xmss_params *params, unsigned char *leaf,
                    uint32_t ltree_addr[8], uint32_t ots_addr[8]);
 
 /**
- * Used for pseudo-random key generation.
- * Generates the seed for the WOTS key pair at address 'addr'.
- *
- * Takes n-byte sk_seed and returns n-byte seed using 32 byte address 'addr'.
- */
-void get_seed(const xmss_params *params, unsigned char *seed,
-              const unsigned char *sk_seed, uint32_t addr[8]);
-
-/**
  * Verifies a given message signature pair under a given public key.
  * Note that this assumes a pk without an OID, i.e. [root || PUB_SEED]
  */

--- a/xmss_core.c
+++ b/xmss_core.c
@@ -174,7 +174,6 @@ int xmssmt_core_sign(const xmss_params *params,
 
     unsigned char root[params->n];
     unsigned char *mhash = root;
-    unsigned char ots_seed[params->n];
     unsigned long long idx;
     unsigned char idx_bytes_32[32];
     unsigned int i;
@@ -217,13 +216,10 @@ int xmssmt_core_sign(const xmss_params *params,
         set_tree_addr(ots_addr, idx);
         set_ots_addr(ots_addr, idx_leaf);
 
-        /* Get a seed for the WOTS keypair. */
-        get_seed(params, ots_seed, sk_seed, ots_addr);
-
         /* Compute a WOTS signature. */
         /* Initially, root = mhash, but on subsequent iterations it is the root
            of the subtree below the currently processed subtree. */
-        wots_sign(params, sm, root, ots_seed, pub_seed, ots_addr);
+        wots_sign(params, sm, root, sk_seed, pub_seed, ots_addr);
         sm += params->wots_sig_bytes;
 
         /* Compute the authentication path for the used WOTS leaf. */

--- a/xmss_core_fast.c
+++ b/xmss_core_fast.c
@@ -623,7 +623,6 @@ int xmss_core_sign(const xmss_params *params,
     // Init working params
     unsigned char R[params->n];
     unsigned char msg_h[params->n];
-    unsigned char ots_seed[params->n];
     uint32_t ots_addr[8] = {0};
 
     // ---------------------------------
@@ -670,11 +669,8 @@ int xmss_core_sign(const xmss_params *params,
     set_type(ots_addr, 0);
     set_ots_addr(ots_addr, idx);
 
-    // Compute seed for OTS key pair
-    get_seed(params, ots_seed, sk_seed, ots_addr);
-
     // Compute WOTS signature
-    wots_sign(params, sm, msg_h, ots_seed, pub_seed, ots_addr);
+    wots_sign(params, sm, msg_h, sk_seed, pub_seed, ots_addr);
 
     sm += params->wots_sig_bytes;
     *smlen += params->wots_sig_bytes;
@@ -707,7 +703,6 @@ int xmss_core_sign(const xmss_params *params,
 int xmssmt_core_keypair(const xmss_params *params,
                         unsigned char *pk, unsigned char *sk)
 {
-    unsigned char ots_seed[params->n];
     uint32_t addr[8] = {0};
     unsigned int i;
     unsigned char *wots_sigs;
@@ -745,8 +740,7 @@ int xmssmt_core_keypair(const xmss_params *params,
         // Compute seed for OTS key pair
         treehash_init(params, pk, params->tree_height, 0, states + i, sk+params->index_bytes, pk+params->n, addr);
         set_layer_addr(addr, (i+1));
-        get_seed(params, ots_seed, sk + params->index_bytes, addr);
-        wots_sign(params, wots_sigs + i*params->wots_sig_bytes, pk, ots_seed, pk+params->n, addr);
+        wots_sign(params, wots_sigs + i*params->wots_sig_bytes, pk, sk + params->index_bytes, pk+params->n, addr);
     }
     // Address now points to the single tree on layer d-1
     treehash_init(params, pk, params->tree_height, 0, states + i, sk+params->index_bytes, pk+params->n, addr);
@@ -783,7 +777,6 @@ int xmssmt_core_sign(const xmss_params *params,
     // Init working params
     unsigned char R[params->n];
     unsigned char msg_h[params->n];
-    unsigned char ots_seed[params->n];
     uint32_t addr[8] = {0};
     uint32_t ots_addr[8] = {0};
     unsigned char idx_bytes_32[32];
@@ -867,11 +860,8 @@ int xmssmt_core_sign(const xmss_params *params,
     set_tree_addr(ots_addr, idx_tree);
     set_ots_addr(ots_addr, idx_leaf);
 
-    // Compute seed for OTS key pair
-    get_seed(params, ots_seed, sk_seed, ots_addr);
-
     // Compute WOTS signature
-    wots_sign(params, sm, msg_h, ots_seed, pub_seed, ots_addr);
+    wots_sign(params, sm, msg_h, sk_seed, pub_seed, ots_addr);
 
     sm += params->wots_sig_bytes;
     *smlen += params->wots_sig_bytes;
@@ -929,8 +919,7 @@ int xmssmt_core_sign(const xmss_params *params,
             set_tree_addr(ots_addr, ((idx + 1) >> ((i+2) * params->tree_height)));
             set_ots_addr(ots_addr, (((idx >> ((i+1) * params->tree_height)) + 1) & ((1 << params->tree_height)-1)));
 
-            get_seed(params, ots_seed, sk+params->index_bytes, ots_addr);
-            wots_sign(params, wots_sigs + i*params->wots_sig_bytes, states[i].stack, ots_seed, pub_seed, ots_addr);
+            wots_sign(params, wots_sigs + i*params->wots_sig_bytes, states[i].stack, sk_seed, pub_seed, ots_addr);
 
             states[params->d + i].stackoffset = 0;
             states[params->d + i].next_leaf = 0;


### PR DESCRIPTION
In the [public comments](https://csrc.nist.gov/CSRC/media/Publications/sp/800-208/draft/documents/sp800-208-draft-comments-received.pdf) to draft version of [NIST Special Publication 800-208](https://csrc.nist.gov/publications/detail/sp/800-208/draft), ETSI TC CYBER WG QSC identified a multi-target attack against the method of pseudorandom key generation used in this referrence implementation. ETSI TC CYBER WG QSC suggested using the pseudorandom key generation method from SPHINCS+, however, there is still a multi-user attack against that key generation method.

This PR revises the pseudorandom key generation method by using the method from SPINCS+, but adding SEED as an input in order to protect against multi-user attacks. Since prf() only accepts 32-byte inputs, the new key generation method uses a new PRF. The resulting key generation method is sk[i] = prf_keygen(sk_seed, pub_seed || adrs).