### PR TITLE
Add 'vectors.c' to the 'TEST' variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ TESTS = test/wots \
 		test/xmssmt_fast \
 		test/maxsigsxmss \
 		test/maxsigsxmssmt \
+		test/vectors \
 
 UI = ui/xmss_keypair \
 	 ui/xmss_sign \


### PR DESCRIPTION
Simply include the (missing?) `vectors.c` test program in the Makefile so that the corresponding executable is produced when using `make`.